### PR TITLE
add ungroup() to fix error from CalculateAll() call:

### DIFF
--- a/R/CalculateAll.R
+++ b/R/CalculateAll.R
@@ -237,7 +237,8 @@ CalculateAll = function(conf, layers, debug=F){
       # calculate weighted mean by area
       group_by(goal, dimension) %>%
       summarise(score = weighted.mean(score, area, na.rm=T),
-                region_id = 0)) 
+                region_id = 0) %>%
+      ungroup()) 
     
   
   ## post-process


### PR DESCRIPTION
Calculating FinalizeScores function...
 Error in order(goal = list(scores = c("FIS", "FIS", "FIS", "FIS", "FIS",  :
  unimplemented type 'list' in 'listgreater'